### PR TITLE
Proposed fix for issue #14

### DIFF
--- a/mongo_migrate
+++ b/mongo_migrate
@@ -185,8 +185,11 @@ while getopts "hf:c:t:gr" OPT; do
 
 [ -n "$RUN" -a "$TARGET" != "up" -a "$TARGET" != "down" ] && usage
 
-#load custom configs (overides defaults)
+#load custom configs (overrides defaults)
 source $CONFIG_PATH
+
+#ensure trailing slash on MIGRATION_DIR
+MIGRATION_DIR=${MIGRATION_DIR%/}/
 
 #Check migration dir
 ensure_migration_dir


### PR DESCRIPTION
As per issue #14, not requiring `MIGRATION_DIR` to be set to a value ending in a `/`.
