### PR TITLE
Default values mongo_migrate script

### DIFF
--- a/mongo_migrate
+++ b/mongo_migrate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ### BEGIN INFO
 # Provides:          Mongodb migration manager
@@ -162,8 +162,8 @@ run_all() {
 ## SCRIPT RUN
 
 #Convention configs
-MONGO_HOST=localhost
-MIGRATION_DIR="db/migrate/"
+MONGO_HOST="${MONGO_HOST:-localhost}"
+MIGRATION_DIR="${MIGRATION_DIR:-db/migrate/}"
 CONFIG_PATH=./config.cfg
 
 #Parameter extraction


### PR DESCRIPTION
Improvements in mongo_migrate script to support default values via environment variables (Useful in docker). 
The script does not work with /bin/sh due `sh: -gt: argument expected`. Replaced with /bin/bash.